### PR TITLE
[ros-o] drop c++11 compiler flag

### DIFF
--- a/pal_statistics/CMakeLists.txt
+++ b/pal_statistics/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(catkin REQUIRED COMPONENTS
   rosbag
 )
 catkin_python_setup()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS thread)
 


### PR DESCRIPTION
compilation broke on newer systems as log4cxx requires c++17 for quite some time now.

You probably do not want this in the kinetic-devel branch anymore, so I called it `noetic-devel` in the PR.

Also, please merge https://github.com/pal-robotics/pal_statistics/pull/1 which I [cherry-picked for ros-o](https://github.com/ros-o/pal_statistics/commits/obese-devel) as the old library name doesn't exist for a while.
Not sure who uses this script, but it's broken without the PR.