### PR TITLE
[ROS-O] do not rely on extension for std::vector<bool>

### DIFF
--- a/pal_statistics/src/pal_statistics_utils.cpp
+++ b/pal_statistics/src/pal_statistics_utils.cpp
@@ -204,7 +204,7 @@ void RegistrationList::deleteElement(size_t index)
   ids_.resize(ids_.size() - 1);
   std::swap(references_[index], references_.back());
   references_.resize(references_.size() - 1);
-  std::swap(enabled_[index], enabled_.back());
+  enabled_.swap(enabled_[index], enabled_.back());
   enabled_.resize(enabled_.size() - 1);
 
   registrationsChanged();


### PR DESCRIPTION
The standard does not define std::swap() for the bit proxy objects, but defines a static method instead. This broke with clang++ 14.0.6 over here.

See here for more details:
https://stackoverflow.com/a/58660208/21260084