### PR TITLE
Use enabled_.swap instead of std::swap.

### DIFF
--- a/pal_statistics/src/registration_list.cpp
+++ b/pal_statistics/src/registration_list.cpp
@@ -207,7 +207,7 @@ void RegistrationList::deleteElement(size_t index)
   ids_.resize(ids_.size() - 1);
   std::swap(references_[index], references_.back());
   references_.resize(references_.size() - 1);
-  std::swap(enabled_[index], enabled_.back());
+  enabled_.swap(enabled_[index], enabled_.back());
   enabled_.resize(enabled_.size() - 1);
 
   registrationsChanged();


### PR DESCRIPTION
This allows this package to compile on modern g++, on Ubuntu 24.04.

This is the equivalent of https://github.com/pal-robotics/pal_statistics/pull/14 , but for ROS 2.  See https://stackoverflow.com/questions/58660207/why-doesnt-stdswap-work-on-vectorbool-elements-under-clang-win/58660208#58660208 on details why we need this.

This should fix the failing build on ROS 2 Rolling, like in https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__pal_statistics__ubuntu_noble_amd64__binary/12/console