### PR TITLE
Fix compilation on Windows by exporting all symbols with CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS

### DIFF
--- a/pal_statistics/CMakeLists.txt
+++ b/pal_statistics/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(pal_statistics)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 


### PR DESCRIPTION


The package compiles a shared library, but does not expose any symbol on Windows, so if the CMake project is compiled on Windows, no import library `.lib` is actually generated.

On Linux and macOS, everything compiles fine as by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable, so this PR sets the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` variable to `ON`, to ensure that the compilation works fine on Windows.