### PR TITLE
Fix loongarch64 atomic build error

### DIFF
--- a/pal_statistics/CMakeLists.txt
+++ b/pal_statistics/CMakeLists.txt
@@ -40,6 +40,10 @@ if(BUILD_TESTING)
     pal_statistics-test PRIVATE src) # dirty hack for a forward declaration
   target_link_libraries(pal_statistics-test ${PROJECT_NAME})
 
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "loongarch64")
+    target_link_libraries(pal_statistics-test atomic)
+  endif()
+
   # Add pal_statistics_py.test
   ament_add_pytest_test(pal_statistics_pytest test/test_pal_statistics.py)
 endif()


### PR DESCRIPTION
Dear maintainer，
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html

When I execute the following command on a loongarch64 debian environment：

```
PKG_CONFIG=/usr/bin/pkg-config cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DFETCHCONTENT_FULLY_DISCONNECTED=ON "-GUnix Makefiles" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_LIBDIR=lib/loongarch64-linux-gnu -DCMAKE_INSTALL_PREFIX=/opt/ros/jazzy -DAMENT_PREFIX_PATH=/opt/ros/jazzy -DCMAKE_PREFIX_PATH=/opt/ros/jazzy
make -j1 VERBOSE=1
```


I get an error:


```
[100%] Linking CXX executable pal_statistics-test
/usr/bin/cmake -E cmake_link_script CMakeFiles/pal_statistics-test.dir/link.txt --verbose=1
/usr/bin/ld: libpal_statistics.so: undefined reference to `__atomic_store_16'      
/usr/bin/ld: libpal_statistics.so: undefined reference to `__atomic_load_16'    
/usr/bin/ld: libpal_statistics.so: undefined reference to `__atomic_compare_exchange_16'  
```      
I submitted a fix for the above problem and completed the test verification locally.