### PR TITLE
Modernize Python code to Python 3

### DIFF
--- a/pal_carbon_collector/scripts/carbon_collector_node.py
+++ b/pal_carbon_collector/scripts/carbon_collector_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import graphitesend
 import rospy
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     rospy.init_node('carbon_collector_node')
 
     if not rospy.has_param('~topics'):
-        print "No topics were specified"
+        print("No topics were specified")
         sys.exit(1)
 
     topics = rospy.get_param('~topics')

--- a/pal_carbon_collector/src/pal_carbon_collector/carbon_collector.py
+++ b/pal_carbon_collector/src/pal_carbon_collector/carbon_collector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import graphitesend
 import rospy
@@ -25,7 +25,7 @@ class CarbonCollector:
         result = self.gs.send_list(stats, timestamp.to_sec())
 
         if self.dry_run:
-            print result
+            print(result)
 
         return result
 

--- a/pal_statistics/pal_statistics/statistics_registry.py
+++ b/pal_statistics/pal_statistics/statistics_registry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 PAL Robotics S.L.
 #
@@ -32,6 +32,8 @@
 from pal_statistics_msgs.msg import Statistic, Statistics, StatisticsNames, StatisticsValues
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+
+__all__ = ['Registration', 'StatisticsRegistry']
 
 
 class Registration:

--- a/pal_statsd_collector/scripts/statsd_collector_node.py
+++ b/pal_statsd_collector/scripts/statsd_collector_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import rospy
 import sys
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     rospy.init_node('statsd_collector_node')
 
     if not rospy.has_param('~topics'):
-        print "No topics were specified"
+        print("No topics were specified")
         sys.exit(1)
 
     topics = rospy.get_param('~topics')


### PR DESCRIPTION
This PR modernizes the Python codebase to Python 3 standards:

- Updates shebangs to explicitly use python3
- Converts Python 2 print statements to print() functions  
- Adds `__all__` declaration for better module documentation